### PR TITLE
Adding C-Layer to DApps security contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This document is a work in progress. We're happy to accept feedback, questions, 
 | Bancor Network | | security@bancor.network | |
 | BarterDEX Network | | security@komodoplatform.com | |
 | Bloom | [External Reference](https://bloom.co/docs/contracts/accounts/) | team@bloom.co | |
-| C-Layer | [Dapps](https://dapp.c-layer.org/) | security@c-layer.org | [Compliance Layer](https://c-layer.org/) |
+| C-Layer | [External Reference](https://dapp.c-layer.org/) | security@c-layer.org | [Compliance Layer](https://c-layer.org/) |
 | Connext | | support@connext.network | |
 | Decentralized Vulnerability Platform | | service@dvpnet.io | |
 | Democracy Earth | | hello@democracy.earth | |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This document is a work in progress. We're happy to accept feedback, questions, 
 | Bancor Network | | security@bancor.network | |
 | BarterDEX Network | | security@komodoplatform.com | |
 | Bloom | [External Reference](https://bloom.co/docs/contracts/accounts/) | team@bloom.co | |
-| C-Layer | [External Reference](https://dapp.c-layer.org/) | security@c-layer.org | [Compliance Layer](https://c-layer.org/) |
+| C-Layer | [External Reference](https://c-layer.org/) | security@c-layer.org | |
 | Connext | | support@connext.network | |
 | Decentralized Vulnerability Platform | | service@dvpnet.io | |
 | Democracy Earth | | hello@democracy.earth | |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This document is a work in progress. We're happy to accept feedback, questions, 
 | Bancor Network | | security@bancor.network | |
 | BarterDEX Network | | security@komodoplatform.com | |
 | Bloom | [External Reference](https://bloom.co/docs/contracts/accounts/) | team@bloom.co | |
-| Compound Finance | | security@compound.finance | |
+| C-Layer | [Compliance Layer](https://c-layer.org/) | Defi | security@c-layer.org | [Repository](https://github.com/c-layer/contracts) |
 | Connext | | support@connext.network | |
 | Decentralized Vulnerability Platform | | service@dvpnet.io | |
 | Democracy Earth | | hello@democracy.earth | |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This document is a work in progress. We're happy to accept feedback, questions, 
 | Bancor Network | | security@bancor.network | |
 | BarterDEX Network | | security@komodoplatform.com | |
 | Bloom | [External Reference](https://bloom.co/docs/contracts/accounts/) | team@bloom.co | |
-| C-Layer | [Compliance Layer](https://c-layer.org/) | Defi | security@c-layer.org | [Repository](https://github.com/c-layer/contracts) |
+| C-Layer | [Dapps](https://dapp.c-layer.org/) | security@c-layer.org | [Compliance Layer](https://c-layer.org/) |
 | Connext | | support@connext.network | |
 | Decentralized Vulnerability Platform | | service@dvpnet.io | |
 | Democracy Earth | | hello@democracy.earth | |


### PR DESCRIPTION
C-Layer is a multi token framework with a main focus on executing DeFi compliance on-chain.

We currently have two sets of token core deployed on the mainnet:
- 0x14cA4d241D6061775cFe82A24e90b2b7Db822aDb
- 0xF0C57e93Bd88CF45697a29B5f184768783531966

I am welcoming feedbacks about my PR.
