### PR TITLE
Update Aragon bug bounty link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This document is a work in progress. We're happy to accept feedback, questions, 
 | --- | --- | --- | --- |
 | 0x | [External Reference](https://0xproject.com/wiki#Deployed-Addresses) | team@0xproject.com | [Bug bounty](https://0xproject.com/wiki#Bug-Bounty) |
 | 1Hive | | [Keybase Chat](https://1hive.org/contribute/bug-bounty#reporting) | [Bug bounty](https://1hive.org/contribute/bug-bounty) |
-| Aragon | [External Reference](https://github.com/aragon/deployments/tree/master/environments/mainnet) | security@aragon.org | [Bug bounty](https://wiki.aragon.org/dev/bug_bounty/) |
+| Aragon | [External Reference](https://github.com/aragon/deployments/tree/master/environments/mainnet) | security@aragon.org | [Bug bounty](https://wiki.aragon.org/association/security/#smart-contract-bug-bounty) |
 | Bancor Network | | security@bancor.network | |
 | BarterDEX Network | | security@komodoplatform.com | |
 | Bloom | [External Reference](https://bloom.co/docs/contracts/accounts/) | team@bloom.co | |


### PR DESCRIPTION
The old link now 404s.