### PR TITLE
docs: Fix: Added Etherscan link for Ampleforth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This document is a work in progress. We're happy to accept feedback, questions, 
 | Aeternity | AE | [Etherscan](https://etherscan.io/token/0x5ca9a71b1d01849c0a95490cc00559717fcf0d1d) | info@aeternity.com | |
 | Aion | AION | [Etherscan](https://etherscan.io/token/0x4CEdA7906a5Ed2179785Cd3A40A69ee8bc99C466) | hello@aion.network | |
 | AirSwap | AST | [Etherscan](https://etherscan.io/token/0x27054b13b1b798b345b591a4d22e6562d47ea75a) | bounty@airswap.io | [Bug bounty](https://medium.com/fluidity/smart-contracts-and-bug-bounty-ad75733eb53f) |
-| Ampleforth | AMPL | [Etherscan](0xd46ba6d942050d489dbd938a2c909a5d5039a161) | dev-support@ampleforth.org | |
+| Ampleforth | AMPL | [Etherscan](https://etherscan.io/token/0xd46ba6d942050d489dbd938a2c909a5d5039a161) | dev-support@ampleforth.org | |
 | Aragon | ANT | [Etherscan](https://etherscan.io/token/0x960b236A07cf122663c4303350609A66A7B288C0) | security@aragon.org | [Bug bounty](https://wiki.aragon.org/dev/bug_bounty/) |
 | Augur | REP | [Etherscan](https://etherscan.io/token/0x1985365e9f78359a9B6AD760e32412f4a445E862) | bounty@augur.net | [Bug bounty](https://www.augur.net/bounty/) |
 | Aurora | AOA | [Etherscan](https://etherscan.io/token/0x9ab165d795019b6d8b3e971dda91071421305e5a) | info@aurorachain.io | |


### PR DESCRIPTION
I noticed that the **Ampleforth** token entry in the **ERC20 Tokens** table was missing an Etherscan link in the **Mainnet Address** column, unlike other tokens. I've fixed this by adding the correct link in the proper format.  

The corrected line now looks like this:  
```
Ampleforth | AMPL | [Etherscan](https://etherscan.io/token/0xd46ba6d942050d489dbd938a2c909a5d5039a161) | dev-support@ampleforth.org | |
```  

This ensures consistency with the rest of the table.